### PR TITLE
Stop subsequent tasks from failing if a glob expands to no files to process.

### DIFF
--- a/src/grunt-spritesmith.js
+++ b/src/grunt-spritesmith.js
@@ -61,6 +61,11 @@ module.exports = function (grunt) {
     // Create an async callback
     var cb = this.async();
 
+    // Quit if there are no images to process.
+    if (Object.keys(srcFiles).length === 0) {
+      return cb(true);
+    }
+
     // Determine the format of the image
     var imgOpts = data.imgOpts || {},
         imgFormat = imgOpts.format || imgFormats.get(destImg) || 'png';


### PR DESCRIPTION
The task was failing and causing all subsequent grunt tasks to fail if a blob was expanding to no files to process.  This is useful for setting up grunt-spritesmith for new projects without any images to process yet.  It also matches the behavior of other grunt tasks like concat.
