### PR TITLE
Allow parallel spritesheets by adding support for spriteName option

### DIFF
--- a/src/grunt-spritesmith.js
+++ b/src/grunt-spritesmith.js
@@ -113,8 +113,10 @@ module.exports = function (grunt) {
       // Render the variables via json2css
       var cssFormat = data.cssFormat || cssFormats.get(destCSS) || 'json',
           spritePath = data.imgPath || url.relative(destCSS, destImg),
+          spriteName = data.spriteName || false,
           formatOpts = {
-            'spritePath': spritePath
+            'spritePath': spritePath,
+            'spriteName': spriteName
           },
           cssStr = json2css(cleanCoords, {'format': cssFormat, 'formatOpts': formatOpts});
 


### PR DESCRIPTION
[See https://github.com/twolfson/json2css/pull/6]

My goal is to be able to create multiple spritesheets for a given site and import them into the same master stylesheet (via a preprocessor). Useful when spritesheets start becoming impractically large. It didn't work with the current setup, because the mixin names plugged into the different sprite stylesheets would override each other and get tangled up. So I tried to add support for a "spriteName" property: when set, it adds to the mixin names in the output sprite stylesheet, making them specific to a certain sprite -- that way, for instance, i could have one sprite mixin for sprite-universal and another for sprite-pageone.

So I added a couple of lines to grunt-spritesmith.js and modified the mustache templates in json2css (see url above).
