### PR TITLE
Add option to pass a custom mustache template to json2css

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ grunt.initConfig({
           // (stylus, scss, sass, less, json, jsonArray, css)
       'cssFormat': 'json',
 
+      // OPTIONAL: Specify a Mustache template to use for destCSS; mutually exclusive to cssFormat
+      'cssTemplate': 'public/css/sprite_positions.styl.mustache',
+
       // OPTIONAL: Specify settings for engine
       'engineOpts': {
         'imagemagick': true

--- a/src-test/expected_files/sprite_positions_custom_template.styl
+++ b/src-test/expected_files/sprite_positions_custom_template.styl
@@ -1,0 +1,53 @@
+$sprite-sprite1-x = 0px;
+$sprite-sprite1-y = 0px;
+$sprite-sprite1-offset-x = 0px;
+$sprite-sprite1-offset-y = 0px;
+$sprite-sprite1-width = 50px;
+$sprite-sprite1-height = 50px;
+$sprite-sprite1-total-width = 100px;
+$sprite-sprite1-total-height = 300px;
+$sprite-sprite1-image = 'sprite.png';
+$sprite-sprite1 = 0px 0px 0px 0px 50px 50px 100px 300px 'sprite.png';
+$sprite-sprite2-x = 0px;
+$sprite-sprite2-y = 50px;
+$sprite-sprite2-offset-x = 0px;
+$sprite-sprite2-offset-y = -50px;
+$sprite-sprite2-width = 50px;
+$sprite-sprite2-height = 50px;
+$sprite-sprite2-total-width = 100px;
+$sprite-sprite2-total-height = 300px;
+$sprite-sprite2-image = 'sprite.png';
+$sprite-sprite2 = 0px 50px 0px -50px 50px 50px 100px 300px 'sprite.png';
+$sprite-sprite3-x = 0px;
+$sprite-sprite3-y = 100px;
+$sprite-sprite3-offset-x = 0px;
+$sprite-sprite3-offset-y = -100px;
+$sprite-sprite3-width = 100px;
+$sprite-sprite3-height = 200px;
+$sprite-sprite3-total-width = 100px;
+$sprite-sprite3-total-height = 300px;
+$sprite-sprite3-image = 'sprite.png';
+$sprite-sprite3 = 0px 100px 0px -100px 100px 200px 100px 300px 'sprite.png';
+
+spriteWidth($sprite) {
+  width: $sprite[4];
+}
+
+spriteHeight($sprite) {
+  height: $sprite[5];
+}
+
+spritePosition($sprite) {
+  background-position: $sprite[2] $sprite[3];
+}
+
+spriteImage($sprite) {
+  background-image: url($sprite[8]);
+}
+
+sprite($sprite) {
+  spriteImage($sprite)
+  spritePosition($sprite)
+  spriteWidth($sprite)
+  spriteHeight($sprite)
+}

--- a/src-test/grunt-spritesmith.test.js
+++ b/src-test/grunt-spritesmith.test.js
@@ -102,5 +102,17 @@ module.exports = {
 
     // Callback
     test.done();
+  },
+  // DEV: This is testing an edge case. A custom template is not critical for module functionality.
+  'cssTemplate': function (test) {
+    // Setup
+    var expectedCoords = fs.readFileSync(__dirname + '/expected_files/sprite_positions_custom_template.styl', 'utf8'),
+        actualCoords = fs.readFileSync(__dirname + '/scratch/sprite_positions_custom_template.styl', 'utf8');
+
+    // Make sure the outputs match
+    test.strictEqual(actualCoords, expectedCoords, 'Generated output doesn\'t match expected output.');
+
+    // Callback
+    test.done();
   }
 };

--- a/src-test/grunt.js
+++ b/src-test/grunt.js
@@ -49,6 +49,14 @@ module.exports = function (grunt) {
             return '#container .' + item.name;
           }
         }
+      },
+      'cssTemplate': {
+        // TODO: This order is forced due to png/jpg ordering. We should fix this.
+        // src: 'test_sprites/*.{jpg,png}',
+        src: ['test_sprites/sprite1.png','test_sprites/sprite2.jpg','test_sprites/sprite3.png'],
+        destImg: 'scratch/sprite.png',
+        destCSS: 'scratch/sprite_positions_custom_template.styl',
+        cssTemplate: 'test_template.mustache'
       }
     },
     test: {

--- a/src-test/test_template.mustache
+++ b/src-test/test_template.mustache
@@ -1,0 +1,42 @@
+{
+  // Default options
+  'functions': true
+}
+
+{{#items}}
+$sprite-{{name}}-x = {{px.x}};
+$sprite-{{name}}-y = {{px.y}};
+$sprite-{{name}}-offset-x = {{px.offset_x}};
+$sprite-{{name}}-offset-y = {{px.offset_y}};
+$sprite-{{name}}-width = {{px.width}};
+$sprite-{{name}}-height = {{px.height}};
+$sprite-{{name}}-total-width = {{px.total_width}};
+$sprite-{{name}}-total-height = {{px.total_height}};
+$sprite-{{name}}-image = '{{{escaped_image}}}';
+$sprite-{{name}} = {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.height}} {{px.total_width}} {{px.total_height}} '{{{escaped_image}}}';
+{{/items}}
+
+{{#options.functions}}
+spriteWidth($sprite) {
+  width: $sprite[4];
+}
+
+spriteHeight($sprite) {
+  height: $sprite[5];
+}
+
+spritePosition($sprite) {
+  background-position: $sprite[2] $sprite[3];
+}
+
+spriteImage($sprite) {
+  background-image: url($sprite[8]);
+}
+
+sprite($sprite) {
+  spriteImage($sprite)
+  spritePosition($sprite)
+  spriteWidth($sprite)
+  spriteHeight($sprite)
+}
+{{/options.functions}}

--- a/src/grunt-spritesmith.js
+++ b/src/grunt-spritesmith.js
@@ -49,6 +49,7 @@ module.exports = function (grunt) {
         src = data.src,
         destImg = data.destImg,
         destCSS = data.destCSS,
+        cssTemplate = data.cssTemplate,
         that = this;
 
     // Verify all properties are here
@@ -121,10 +122,19 @@ module.exports = function (grunt) {
         cleanCoords.push(coords);
       });
 
+      var cssFormat = 'spritesmith-custom',
+          cssOptions = data.cssOpts || {};
+
+      // If there's a custom template, use it
+      if (cssTemplate) {
+        json2css.addMustacheTemplate(cssFormat, fs.readFileSync(cssTemplate, 'utf8'));
+      } else {
+      // Otherwise, override the cssFormat and fallback to 'json'
+        cssFormat = data.cssFormat || cssFormats.get(destCSS) || 'json';
+      }
+
       // Render the variables via json2css
-      var cssFormat = data.cssFormat || cssFormats.get(destCSS) || 'json',
-          cssOptions = data.cssOpts || {},
-          cssStr = json2css(cleanCoords, {'format': cssFormat, 'formatOpts': cssOptions});
+      var cssStr = json2css(cleanCoords, {'format': cssFormat, 'formatOpts': cssOptions});
 
       // Write it out to the CSS file
       var destCSSDir = path.dirname(destCSS);


### PR DESCRIPTION
A custom template file can be specified for json2css to use.

Because all of my sprites are in the same spritesheet, I would like to use [Stylus' @extend directive](http://learnboost.github.io/stylus/docs/extend.html) to have all sprites extend from a `$sprite` placeholder class rather than use a mix-in.

This also allows for greater customization of the variable names. I use dashes in my Stylus variable names; with the custom template I can keep the sprite variables consistent with my other variables.
