### PR TITLE
rename grunt.js to Gruntfile.js, migrate to grunt-contrib-jshint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,13 @@
 module.exports = function (grunt) {
   grunt.initConfig({
-    lint: {
+    jshint: {
       all: ["grunt.js", "tasks/*.js", "src-test/*.js"]
     }
   });
 
-  grunt.registerTask("default", "lint");
+  grunt.registerTask("default", "jshint");
+
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+
   grunt.loadTasks("tasks");
 };

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "grunt-contrib-clean": "~0.3.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
+    "grunt": "~0.4.2",
     "grunt-contrib-nodeunit": "~0.1.2",
     "grunt-contrib-clean": "~0.4.0"
   },


### PR DESCRIPTION
The `grunt` command (since grunt-cli 0.4?) doesn't find "grunt.js" but does find "Gruntfile.js".  Rename the file, and migrate off of the old 0.3 Grunt `lint` task to `jshint`.

Before
![screen shot 2013-11-24 at 3 24 58 pm](https://f.cloud.github.com/assets/1527302/1609902/1de6b178-5560-11e3-9054-1d811064787e.png)

After
![screen shot 2013-11-24 at 3 28 13 pm](https://f.cloud.github.com/assets/1527302/1609903/201caf2e-5560-11e3-8b54-070c0cf8c956.png)
