### PR TITLE
Add npm dependencies to engine descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ The `pngsmith` engine uses [`pngparse`][], an JavaScript `png` parser, to interp
 
 **Key differences:** It requires no additional installation steps but you are limited to `.png` files for your source files.
 
+**Required Packages:** `pngsmith`
+
 [`pngparse`]: https://github.com/darkskyapp/pngparse
 [`ndarrays`]: https://github.com/mikolalysenko/ndarray
 
@@ -285,6 +287,8 @@ The `pngsmith` engine uses [`pngparse`][], an JavaScript `png` parser, to interp
 The `phantomjs` engine relies on having [phantomjs][] installed on your machine. Visit [the phantomjs website][phantomjs] for installation instructions.
 
 **Key differences:** `phantomjs` is the easiest engine to install that supports all image formats.
+
+**Required Packages:** `phantomjssmith`
 
 [spritesmith][] has been tested against `phantomjs@1.9.0`.
 
@@ -294,6 +298,8 @@ The `phantomjs` engine relies on having [phantomjs][] installed on your machine.
 The `canvas` engine uses [node-canvas][] which has a dependency on [Cairo][cairo].
 
 **Key differences:** `canvas` has the best performance (useful for over 100 sprites). However, it is `UNIX` only.
+
+**Required Packages:** `canvassmith`
 
 Instructions on how to install [Cairo][cairo] are provided in the [node-canvas wiki][node-canvas-wiki].
 
@@ -311,6 +317,8 @@ sudo npm install -g node-gyp
 The `gm` engine depends on [Graphics Magick][graphics-magick] or [Image Magick][image-magick].
 
 **Key differences:** `gm` has the most options for export via `imgOpts`.
+
+**Required Packages:** `gmsmith`
 
 [graphics-magick]: http://www.graphicsmagick.org/
 [image-magick]: http://imagemagick.org/


### PR DESCRIPTION
After installing grunt-spritesmith
`npm install grunt-spritesmith --save-dev`

and setting it up to load some icons originally from a rails project

``` javascript
   //grunt config
    sprite:{
      all: {
        src: ['<%= yeoman.app %>/../../app/assets/images/icons/*.png'],
        destImg: '<%= yeoman.app %>/images/icons.png',
        destCSS: '<%= yeoman.app %>/styles/icons.scss',
        cssFormat: 'scss'
      }
    },
```

after running `grunt sprite --stack` I get this

```
Running "sprite:all" (sprite) task
Fatal error: spawn ENOENT
Error: spawn ENOENT
    at errnoException (child_process.js:980:11)
    at Process.ChildProcess._handle.onexit (child_process.js:771:34)
```

I found where we are calling spawn

```
$ cd node_modules/grunt-spritesmith/
$ grep -R spawn .
./node_modules/spritesmith/node_modules/gmsmith/node_modules/gm/lib/command.js:var spawn = require('child_process').spawn;
./node_modules/spritesmith/node_modules/gmsmith/node_modules/gm/lib/command.js:      self._spawn(self.args(), true, callback);
./node_modules/spritesmith/node_modules/gmsmith/node_modules/gm/lib/command.js:      return self._spawn(self.args(), false, callback);
./node_modules/spritesmith/node_modules/gmsmith/node_modules/gm/lib/command.js:    return this._spawn(args, true, callback);
./node_modules/spritesmith/node_modules/gmsmith/node_modules/gm/lib/command.js:  proto._spawn = function _spawn (args, bufferOutput, callback) {
./node_modules/spritesmith/node_modules/gmsmith/node_modules/gm/lib/command.js:    var proc = spawn(bin, args)
./node_modules/spritesmith/node_modules/pngsmith/node_modules/concat-stream/test.js:var spawn = require('child_process').spawn
./node_modules/spritesmith/node_modules/pngsmith/node_modules/concat-stream/test.js:var cmd = spawn('ls')
```

The spawn is trying to launch "convert" or "identify", but those binaries exist. Assuming there is some irreparable bug, I moved on to a few other less mature sprite frameworks with less success.

I gave grunt-spritesmith another shot, this time searching for the node.js call for spawn, which apparently is compiled. I fired up `dtrace` to see the underlying syscalls. Here is the output when getting the `spawn ENOENT`

```
$ sudo dtruss -n node
//...
58995/0x1da156d:  ioctl(0x2, 0x8004667E, 0x7FFF5FBFE95C)     = 0 0
58995/0x1da156d:  execve("/Users/hulahoop/.rvm/gems/ruby-2.0.0-p353@rally/bin/gm\0", 0x100C00FF0, 0x100C01CD0)     = -1 Err#2
58995/0x1da156d:  execve("/Users/hulahoop/.rvm/gems/ruby-2.0.0-p353@global/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  execve("/Users/hulahoop/.rvm/rubies/ruby-2.0.0-p353/bin/gm\0", 0x100C00FF0, 0x100C01CD0)     = -1 Err#2
58995/0x1da156d:  execve("/Users/hulahoop/.rvm/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  execve("/usr/local/sbin/gm\0", 0x100C00FF0, 0x100C01CD0)     = -1 Err#2
58995/0x1da156d:  execve("/usr/local/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  execve("/usr/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  execve("/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  execve("/usr/sbin/gm\0", 0x100C00FF0, 0x100C01CD0)     = -1 Err#2
58995/0x1da156d:  execve("/sbin/gm\0", 0x100C00FF0, 0x100C01CD0)     = -1 Err#2
58995/0x1da156d:  execve("/opt/X11/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  execve("/usr/X11/bin/gm\0", 0x100C00FF0, 0x100C01CD0)    = -1 Err#2
58995/0x1da156d:  write(0x12, "\002\0", 0x4)     = 4 0
```

Apparently there is some bug loading the "gm" spritesmith engine. I don't have graphicsmagic installed on the system anywhere, and couldn't find it with brew. 

After reading the spritesmith docs it seemed that phantomjs would be the better choice. The docs say I just need to make sure phantomjs is installed.

```
brew install phantomjs
```

```
grunt sprite --stack
Error loading phantomjs { [Error: Cannot find module 'phantomjssmith'] code: 'MODULE_NOT_FOUND' }
Running "sprite:all" (sprite) task
Warning: Sorry, the spritesmith engine 'phantomjs' could not be loaded. Please be sure you have installed it properly on your machine. Use --force to continue.
```

Digging through the source, I found some troubling code.

```
var canvasEngine,
    gmEngine,
    phantomjsEngine,
    pngEngine;
try {
  canvasEngine = require('canvassmith');
} catch (e) {}

try {
  gmEngine = require('gmsmith');
} catch (e) {}

try {
  phantomjsEngine = require('phantomjssmith');
} catch (e) {}

try {
  pngEngine = require('pngsmith');
} catch (e) {}

if (canvasEngine) { addEngine('canvas', canvasEngine); }
if (gmEngine) { addEngine('gm', gmEngine); }
if (phantomjsEngine) { addEngine('phantomjs', phantomjsEngine); }
if (pngEngine) { addEngine('pngsmith', pngEngine); }
```

I did `npm install phantomjssmith --save-dev` then ran `grunt sprite` and everything worked! 

It seems that the main README.md does not mention these packages have to be installed to use the engines. 

I'm going to err on the side that there is something obvious that I missed so that I had to go down this rabbit hole. In case I didn't miss anything, here is a PR to clear this up a bit.
