### PR TITLE
Fix syntax error in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ module.exports = function (grunt) {
 
   // Load in `grunt-spritesmith`
   grunt.loadNpmTasks('grunt-spritesmith');
+};
 ```
 
 Run the `grunt sprite` task:


### PR DESCRIPTION
Add the missing closing squiggly bracket to the "add and configure" JavaScript block in the README.