### PR TITLE
Update to latest get-pixels.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "foundry": "~4.3.2",
     "foundry-release-git": "~2.0.2",
     "foundry-release-npm": "~2.0.2",
-    "get-pixels": "~3.1.0",
+    "get-pixels": "~3.2.3",
     "gmsmith": "~0.5.0",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.13",


### PR DESCRIPTION
Fix npm WARN deprecated pngjs2@1.2.0: pngjs2 has now taken over the original pngjs package on npm. Please change to use pngjs dependency, version 2+.

Din't test that, just updated.