### PR TITLE
Update grunt-spritesmith.js

### DIFF
--- a/src/grunt-spritesmith.js
+++ b/src/grunt-spritesmith.js
@@ -299,7 +299,7 @@ module.exports = function gruntSpritesmith (grunt) {
 
       // Render the variables via `spritesheet-templates`
       var cssStr = templater({
-        sprites: cleanCoords,
+        sprites: typeof data.sortFn === 'function' ? cleanCoords.sort(data.sortFn) : cleanCoords,
         spritesheet: spritesheetInfo,
         spritesheet_info: {
           name: data.cssSpritesheetName


### PR DESCRIPTION
allow config object `sortFn` to optionally sort icons accorging to custom logic before rendering

usage: (e.g. to sort in random order...)
```
{
    sortFn: function(a, b){
      return Math.random() < 0.5 ? -1 : 1;
    },
    src: ['icon-arrow.png', 'icon-circle.png'],
    dest: 'img/icons/sprite.png'
}
```